### PR TITLE
fix Virtuozzo Linux detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
   - 2.6.6
+  - 2.7.3
+  - 3.0.5
 cache: bundler
 script:
   - bundle exec rake app:db:create

--- a/doc/UsefulUtilities/RedhatRelease.html
+++ b/doc/UsefulUtilities/RedhatRelease.html
@@ -99,80 +99,6 @@
   
 </div>
 
-<h2>Overview</h2><div class="docstring">
-  <div class="discussion">
-    
-<p>Redhat releases utilities</p>
-
-
-  </div>
-</div>
-<div class="tags">
-  
-
-</div>
-  <h2>Constant Summary</h2>
-  <dl class="constants">
-    
-      <dt id="LEGACY_DISTRO_TEMPLATE-constant" class="">LEGACY_DISTRO_TEMPLATE =
-        
-      </dt>
-      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>centos%{major_version}</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
-    
-      <dt id="VERSION_SEPARATOR-constant" class="">VERSION_SEPARATOR =
-        <div class="docstring">
-  <div class="discussion">
-    
-<p>this may change to “dot” and “hyphen” if we allow not only final
-releases(beta, custom git builds, etc)</p>
-
-
-  </div>
-</div>
-<div class="tags">
-  
-
-</div>
-      </dt>
-      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>.</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
-    
-      <dt id="VERSION_SEPARATOR_REGEXP-constant" class="">VERSION_SEPARATOR_REGEXP =
-        <div class="docstring">
-  <div class="discussion">
-    
-<p>regexp to match single “dot” character</p>
-
-
-  </div>
-</div>
-<div class="tags">
-  
-
-</div>
-      </dt>
-      <dd><pre class="code"><span class='const'>Regexp</span><span class='period'>.</span><span class='id identifier rubyid_escape'>escape</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="#VERSION_SEPARATOR-constant" title="UsefulUtilities::RedhatRelease::VERSION_SEPARATOR (constant)">VERSION_SEPARATOR</a></span></span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
-    
-      <dt id="VERSION_REGEXP-constant" class="">VERSION_REGEXP =
-        
-      </dt>
-      <dd><pre class="code"><span class='tstring'><span class='regexp_beg'>%r{</span><span class='tstring_content'>              # /etc/redhat-release samples: &quot;CentOS Linux release 7.1.1503 (Core)&quot;, &quot;Red Hat Enterprise Linux Server release 7.2 (Maipo)&quot;
-  (?&lt;=[[:space:]])                # positive lookbehind assertion: ensures that the preceding character matches single &quot;space&quot; character, but doesn&#39;t include this character in the matched text
-  (?&lt;major_version&gt;[[:digit:]])   # :major_version named capture group; it matches single digits
-  </span><span class='embexpr_beg'>#{</span><span class='const'><span class='object_link'><a href="#VERSION_SEPARATOR_REGEXP-constant" title="UsefulUtilities::RedhatRelease::VERSION_SEPARATOR_REGEXP (constant)">VERSION_SEPARATOR_REGEXP</a></span></span><span class='embexpr_end'>}</span><span class='tstring_content'>     # regexp for separator of version parts
-  (?&lt;minor_version&gt;[[:digit:]]+)  # :minor_version named capture group; it matches one or more sequential digits
-  (?:                             # grouping without capturing; &quot;monthstamp&quot; version part don&#39;t exist for versions of Centos older then 7
-    </span><span class='embexpr_beg'>#{</span><span class='const'><span class='object_link'><a href="#VERSION_SEPARATOR_REGEXP-constant" title="UsefulUtilities::RedhatRelease::VERSION_SEPARATOR_REGEXP (constant)">VERSION_SEPARATOR_REGEXP</a></span></span><span class='embexpr_end'>}</span><span class='tstring_content'>   # regexp for separator of version parts
-    (?&lt;monthstamp&gt;[[:digit:]]{4}) # :monthstamp named capture group; it matches 4 sequential digits
-  )?                              # zero or one times quantifier(repetition metacharacter)
-  (?=[[:space:]])                 # positive lookahead assertion: ensures that the following character matches single &quot;space&quot; character, but doesn&#39;t include this character in the matched text
-</span><span class='regexp_end'>}x</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
-    
-      <dt id="DEFAULT_VERSION_ARR-constant" class="">DEFAULT_VERSION_ARR =
-        
-      </dt>
-      <dd><pre class="code"><span class='lbracket'>[</span><span class='int'>6</span><span class='comma'>,</span> <span class='int'>0</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
-    
-  </dl>
 
 
 
@@ -348,7 +274,7 @@ releases(beta, custom git builds, etc)</p>
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#monthstamp-instance_method" title="#monthstamp (instance method)">#<strong>monthstamp</strong>  &#x21d2; Object </a>
+      <a href="#patch_version-instance_method" title="#patch_version (instance method)">#<strong>patch_version</strong>  &#x21d2; Object </a>
     
 
     
@@ -421,12 +347,12 @@ releases(beta, custom git builds, etc)</p>
       <pre class="lines">
 
 
-25
-26
-27</pre>
+29
+30
+31</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 25</span>
+      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 29</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_release_string'>release_string</span><span class='rparen'>)</span>
   <span class='ivar'>@release_string</span> <span class='op'>=</span> <span class='id identifier rubyid_release_string'>release_string</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span>
@@ -469,12 +395,12 @@ releases(beta, custom git builds, etc)</p>
       <pre class="lines">
 
 
-23
-24
-25</pre>
+27
+28
+29</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 23</span>
+      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 27</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_release_string'>release_string</span>
   <span class='ivar'>@release_string</span>
@@ -506,15 +432,15 @@ releases(beta, custom git builds, etc)</p>
       <pre class="lines">
 
 
-33
-34
-35</pre>
+37
+38
+39</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 33</span>
+      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 37</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_legacy_distro'>legacy_distro</span><span class='lparen'>(</span><span class='id identifier rubyid_ver'>ver</span><span class='rparen'>)</span>
-  <span class='const'><span class='object_link'><a href="#LEGACY_DISTRO_TEMPLATE-constant" title="UsefulUtilities::RedhatRelease::LEGACY_DISTRO_TEMPLATE (constant)">LEGACY_DISTRO_TEMPLATE</a></span></span> <span class='op'>%</span> <span class='lbrace'>{</span> <span class='label'>major_version:</span> <span class='id identifier rubyid_ver'>ver</span> <span class='rbrace'>}</span>
+  <span class='const'>LEGACY_DISTRO_TEMPLATE</span> <span class='op'>%</span> <span class='lbrace'>{</span> <span class='label'>major_version:</span> <span class='id identifier rubyid_ver'>ver</span> <span class='rbrace'>}</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -536,12 +462,12 @@ releases(beta, custom git builds, etc)</p>
       <pre class="lines">
 
 
-29
-30
-31</pre>
+33
+34
+35</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 29</span>
+      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 33</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_major_version'>major_version</span><span class='lparen'>(</span><span class='op'>*</span><span class='id identifier rubyid_args'>args</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='op'>*</span><span class='id identifier rubyid_args'>args</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_major_version'>major_version</span>
@@ -572,12 +498,12 @@ releases(beta, custom git builds, etc)</p>
       <pre class="lines">
 
 
-37
-38
-39</pre>
+41
+42
+43</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 37</span>
+      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 41</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_major_version'>major_version</span>
   <span class='id identifier rubyid_version_arr'>version_arr</span><span class='lbracket'>[</span><span class='int'>0</span><span class='rbracket'>]</span>
@@ -602,12 +528,12 @@ releases(beta, custom git builds, etc)</p>
       <pre class="lines">
 
 
-41
-42
-43</pre>
+45
+46
+47</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 41</span>
+      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 45</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_minor_version'>minor_version</span>
   <span class='id identifier rubyid_version_arr'>version_arr</span><span class='lbracket'>[</span><span class='int'>1</span><span class='rbracket'>]</span>
@@ -618,9 +544,9 @@ releases(beta, custom git builds, etc)</p>
 </div>
     
       <div class="method_details ">
-  <h3 class="signature " id="monthstamp-instance_method">
+  <h3 class="signature " id="patch_version-instance_method">
   
-    #<strong>monthstamp</strong>  &#x21d2; <tt>Object</tt> 
+    #<strong>patch_version</strong>  &#x21d2; <tt>Object</tt> 
   
 
   
@@ -632,14 +558,14 @@ releases(beta, custom git builds, etc)</p>
       <pre class="lines">
 
 
-45
-46
-47</pre>
+49
+50
+51</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 45</span>
+      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 49</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_monthstamp'>monthstamp</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_patch_version'>patch_version</span>
   <span class='id identifier rubyid_version_arr'>version_arr</span><span class='lbracket'>[</span><span class='int'>2</span><span class='rbracket'>]</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -662,15 +588,15 @@ releases(beta, custom git builds, etc)</p>
       <pre class="lines">
 
 
-49
-50
-51</pre>
+53
+54
+55</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 49</span>
+      <pre class="code"><span class="info file"># File 'lib/useful_utilities/redhat_release.rb', line 53</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_version_string'>version_string</span>
-  <span class='id identifier rubyid_version_arr'>version_arr</span><span class='period'>.</span><span class='id identifier rubyid_join'>join</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="#VERSION_SEPARATOR-constant" title="UsefulUtilities::RedhatRelease::VERSION_SEPARATOR (constant)">VERSION_SEPARATOR</a></span></span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_version_arr'>version_arr</span><span class='period'>.</span><span class='id identifier rubyid_join'>join</span><span class='lparen'>(</span><span class='const'>VERSION_SEPARATOR</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -682,9 +608,9 @@ releases(beta, custom git builds, etc)</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Mar 12 10:43:42 2018 by
+  Generated on Fri Feb  3 18:43:44 2023 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.3.4).
+  0.9.12 (ruby-3.0.5).
 </div>
 
     </div>

--- a/doc/method_list.html
+++ b/doc/method_list.html
@@ -350,7 +350,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="UsefulUtilities/RedhatRelease.html#monthstamp-instance_method" title="UsefulUtilities::RedhatRelease#monthstamp (method)">#monthstamp</a></span>
+      <span class='object_link'><a href="UsefulUtilities/RedhatRelease.html#patch_version-instance_method" title="UsefulUtilities::RedhatRelease#patch_version (method)">#patch_version</a></span>
       <small>UsefulUtilities::RedhatRelease</small>
     </div>
   </li>

--- a/lib/useful_utilities/redhat_release.rb
+++ b/lib/useful_utilities/redhat_release.rb
@@ -2,23 +2,27 @@ module UsefulUtilities
   # Redhat releases utilities
   class RedhatRelease
     LEGACY_DISTRO_TEMPLATE = 'centos%{major_version}'.freeze
+    private_constant :LEGACY_DISTRO_TEMPLATE
 
     VERSION_SEPARATOR = '.'.freeze # this may change to "dot" and "hyphen" if we allow not only final releases(beta, custom git builds, etc)
     VERSION_SEPARATOR_REGEXP = Regexp.escape(VERSION_SEPARATOR).freeze # regexp to match single "dot" character
+    private_constant :VERSION_SEPARATOR, :VERSION_SEPARATOR_REGEXP
 
     VERSION_REGEXP = %r{              # /etc/redhat-release samples: "CentOS Linux release 7.1.1503 (Core)", "Red Hat Enterprise Linux Server release 7.2 (Maipo)"
       (?<=[[:space:]])                # positive lookbehind assertion: ensures that the preceding character matches single "space" character, but doesn't include this character in the matched text
-      (?<major_version>[[:digit:]])   # :major_version named capture group; it matches single digits
+      (?<major>[[:digit:]])           # :major named capture group; it matches single digits
       #{VERSION_SEPARATOR_REGEXP}     # regexp for separator of version parts
-      (?<minor_version>[[:digit:]]+)  # :minor_version named capture group; it matches one or more sequential digits
-      (?:                             # grouping without capturing; "monthstamp" version part don't exist for versions of Centos older then 7
+      (?<minor>[[:digit:]]+)          # :minor named capture group; it matches one or more sequential digits
+      (?:                             # grouping without capturing; patch version does not exist for versions of CentOS older then 7
         #{VERSION_SEPARATOR_REGEXP}   # regexp for separator of version parts
-        (?<monthstamp>[[:digit:]]{4}) # :monthstamp named capture group; it matches 4 sequential digits
+        (?<patch>[[:digit:]]+)        # :patch named capture group; it matches one or more sequential digits
       )?                              # zero or one times quantifier(repetition metacharacter)
       (?=[[:space:]])                 # positive lookahead assertion: ensures that the following character matches single "space" character, but doesn't include this character in the matched text
     }x.freeze
+    private_constant :VERSION_REGEXP
 
     DEFAULT_VERSION_ARR = [6, 0].freeze
+    private_constant :DEFAULT_VERSION_ARR
 
     attr_reader :release_string
 
@@ -42,7 +46,7 @@ module UsefulUtilities
       version_arr[1]
     end
 
-    def monthstamp
+    def patch_version
       version_arr[2]
     end
 
@@ -58,9 +62,9 @@ module UsefulUtilities
 
     def match_version_arr
       @match_version_arr ||= [
-        version_match[:major_version],
-        version_match[:minor_version],
-        version_match[:monthstamp]
+        version_match[:major],
+        version_match[:minor],
+        version_match[:patch]
       ].compact.map(&:to_i)
     end
 

--- a/lib/useful_utilities/version.rb
+++ b/lib/useful_utilities/version.rb
@@ -1,3 +1,3 @@
 module UsefulUtilities
-  VERSION = '6.6.1'.freeze
+  VERSION = '7.0.0'.freeze
 end

--- a/spec/useful_utilities/redhat_release_spec.rb
+++ b/spec/useful_utilities/redhat_release_spec.rb
@@ -3,119 +3,216 @@ require 'spec_helper'
 describe UsefulUtilities::RedhatRelease do
   let(:service) { described_class.new(release_string) }
 
+  let(:invalid_release) { 'foobar' }
+  let(:centos_5_11) { 'CentOS release 5.11 (Final)' }
+  let(:centos_6_8) { 'CentOS release 6.8 (Final)' }
+  let(:centos_7_1_1503) { 'CentOS Linux release 7.1.1503 (Core)' }
+  let(:rhel_5_11) { 'Red Hat Enterprise Linux Server release 5.11 (Tikanga)' }
+  let(:rhel_6_8) { 'Red Hat Enterprise Linux Server release 6.8 (Santiago)' }
+  let(:rhel_7_2) { 'Red Hat Enterprise Linux Server release 7.2 (Maipo)' }
+  let(:vzlinux_9_0_1) { 'Virtuozzo Linux release 9.0.1 (Vz)' }
+
   describe '.legacy_distro' do
     let(:major_version) { 7 }
 
     subject { described_class.legacy_distro(major_version) }
 
-    it { is_expected.to eq 'centos7' }
+    it { is_expected.to eq('centos7') }
   end
 
   describe '#major_version' do
     subject { service.major_version }
 
-    context 'new versioning format(for versions >= 7.x.x)' do
-      let(:release_string) { 'CentOS Linux release 7.1.1503 (Core)' }
+    context 'for nil release string' do
+      let(:release_string) { nil }
 
-      it { is_expected.to eq 7 }
+      it { is_expected.to eq(6) } 
     end
 
-    context 'old versioning format(for Centos/RHEL release versions < 7.0.x)' do
-      let(:release_string) { 'CentOS release 5.11 (Final)' }
+    context 'for invalid release string' do
+      let(:release_string) { invalid_release }
 
-      it { is_expected.to eq 5 }
+      it { is_expected.to eq(6) } 
+    end
+    
+    context 'for CentOS 5.11' do
+      let(:release_string) { centos_5_11 }
+
+      it { is_expected.to eq(5) }
+    end
+
+    context 'for CentOS 6.8' do
+      let(:release_string) { centos_6_8 }
+
+      it { is_expected.to eq(6) }
+    end
+
+    context 'for CentOS 7.1.1503' do
+      let(:release_string) { centos_7_1_1503 }
+
+      it { is_expected.to eq(7) }
+    end
+
+    context 'for RHEL 5.11' do
+      let(:release_string) { rhel_5_11 }
+
+      it { is_expected.to eq(5) }
+    end
+
+    context 'for Virtuozzo Linux 9.0.1' do
+      let(:release_string) { vzlinux_9_0_1 }
+
+      it { is_expected.to eq(9) } 
     end
   end
 
   describe '#minor_version' do
     subject { service.minor_version }
 
-    context 'new versioning format(for Centos versions >= 7.x.x)' do
-      let(:release_string) { 'CentOS Linux release 7.1.1503 (Core)' }
+    context 'for nil release string' do
+      let(:release_string) { nil }
 
-      it { is_expected.to eq 1 }
+      it { is_expected.to eq(0) } 
     end
 
-    context 'old versioning format(for Centos release versions < 7.0.x and any RHEL ver.)' do
-      let(:release_string) { 'CentOS release 5.11 (Final)' }
+    context 'for invalid release string' do
+      let(:release_string) { invalid_release }
 
-      it { is_expected.to eq 11 }
+      it { is_expected.to eq(0) } 
+    end
+
+    context 'for CentOS 5.11' do
+      let(:release_string) { centos_5_11 }
+
+      it { is_expected.to eq(11) }
+    end
+
+    context 'for CentOS 6.8' do
+      let(:release_string) { centos_6_8 }
+
+      it { is_expected.to eq(8) }
+    end
+
+    context 'for CentOS 7.1.1503' do
+      let(:release_string) { centos_7_1_1503 }
+
+      it { is_expected.to eq(1) }
+    end
+
+    context 'for RHEL 5.11' do
+      let(:release_string) { rhel_5_11 }
+
+      it { is_expected.to eq(11) }
+    end
+
+    context 'for Virtuozzo Linux 9.0.1' do
+      let(:release_string) { vzlinux_9_0_1 }
+
+      it { is_expected.to eq(0) } 
     end
   end
 
-  describe '#monthstamp' do
-    subject { service.monthstamp }
+  describe '#patch_version' do
+    subject { service.patch_version }
 
-    context 'new versioning format(for versions >= 7.x.x)' do
-      let(:release_string) { 'CentOS Linux release 7.1.1503 (Core)' }
+    context 'for nil release string' do
+      let(:release_string) { nil }
 
-      it { is_expected.to eq 1503 }
+      it { is_expected.to be_nil } 
     end
 
-    context 'old versioning format(for Centos/RHEL release versions < 7.0.x)' do
-      let(:release_string) { 'CentOS release 5.11 (Final)' }
+    context 'for invalid release string' do
+      let(:release_string) { invalid_release }
+
+      it { is_expected.to be_nil } 
+    end
+
+    context 'for CentOS 5.11' do
+      let(:release_string) { centos_5_11 }
 
       it { is_expected.to be_nil }
+    end
+
+    context 'for CentOS 6.8' do
+      let(:release_string) { centos_6_8 }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'for CentOS 7.1.1503' do
+      let(:release_string) { centos_7_1_1503 }
+
+      it { is_expected.to eq(1503) }
+    end
+
+    context 'for RHEL 5.11' do
+      let(:release_string) { rhel_5_11 }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'for Virtuozzo Linux 9.0.1' do
+      let(:release_string) { vzlinux_9_0_1 }
+
+      it { is_expected.to eq(1) } 
     end
   end
 
   describe '#version_string' do
     subject { service.version_string }
 
-    context 'Centos release version 5.x' do
-      let(:release_string) { 'CentOS release 5.11 (Final)' }
-
-      it { is_expected.to eq '5.11' }
-    end
-
-    context 'RHEL release version 5.x' do
-      let(:release_string) { 'Red Hat Enterprise Linux Server release 5.11 (Tikanga)' }
-
-      it { is_expected.to eq '5.11' }
-    end
-
-    context 'Centos release version 6.x' do
-      let(:release_string) { 'CentOS release 6.8 (Final)' }
-
-      it { is_expected.to eq '6.8' }
-    end
-
-    context 'RHEL release version 6.x' do
-      let(:release_string) {  'Red Hat Enterprise Linux Server release 6.8 (Santiago)' }
-
-      it { is_expected.to eq '6.8' }
-    end
-
-    context 'Centos release version 7.x.x' do
-      let(:release_string) { 'CentOS Linux release 7.2.1511 (Core)' }
-
-      it { is_expected.to eq '7.2.1511' }
-    end
-
-    context 'RHEL release version 7.x' do
-      let(:release_string) { 'Red Hat Enterprise Linux Server release 7.2 (Maipo)' }
-
-      it { is_expected.to eq '7.2' }
-    end
-  end
-
-  describe '#version_arr' do
-    subject(:version_arr) { service.send(:version_arr) }
-
-    context 'Blank or invalid "release_string" is provided' do
+    context 'for nil release string' do
       let(:release_string) { nil }
 
-      it 'return default version array which corresponds to version 6.0' do
-        expect(version_arr).to eq [6, 0]
-      end
+      it { is_expected.to eq('6.0') } 
     end
 
-    context 'Valid "release_string" is provided' do
-      let(:release_string) { 'CentOS Linux release 7.1.1503 (Core)' }
+    context 'for invalid release string' do
+      let(:release_string) { invalid_release }
 
-      it 'return version array build from regex version match' do
-        expect(version_arr).to eq [7, 1, 1503]
-      end
+      it { is_expected.to eq('6.0') }
+    end
+
+    context 'for CentOS 5.11' do
+      let(:release_string) { centos_5_11 }
+
+      it { is_expected.to eq('5.11') }
+    end
+
+    context 'for CentOS 6.8' do
+      let(:release_string) { centos_6_8 }
+
+      it { is_expected.to eq('6.8') }
+    end
+
+    context 'for CentOS 7.1.1503' do
+      let(:release_string) { centos_7_1_1503 }
+
+      it { is_expected.to eq('7.1.1503') }
+    end
+
+    context 'for RHEL 5.11' do
+      let(:release_string) { rhel_5_11 }
+
+      it { is_expected.to eq('5.11') }
+    end
+
+    context 'for RHEL 6.8' do
+      let(:release_string) { rhel_6_8 }
+
+      it { is_expected.to eq('6.8') }
+    end
+
+    context 'for RHEL 7.2' do
+      let(:release_string) { rhel_7_2 }
+
+      it { is_expected.to eq('7.2') }
+    end
+
+    context 'for Virtuozzo Linux 9.0.1' do
+      let(:release_string) { vzlinux_9_0_1 }
+
+      it { is_expected.to eq('9.0.1') }
     end
   end
 end


### PR DESCRIPTION
Replace `#monthstamp` with `#patch_version` as not all RHEL-compatible linux versions use monthstamp as patch version.